### PR TITLE
Use round_to_sample and higher precision to remove round errors

### DIFF
--- a/align_transcription.py
+++ b/align_transcription.py
@@ -22,14 +22,41 @@ CHIME_DATA = tu.chime_data()
 def correct_time_linear(time_to_correct, linear_fit):
     """Adjust the time using a linear fit of time to lag."""
     corrected = time_to_correct - linear_fit * time_to_correct
-    return corrected
+    return round_to_sample(corrected)
 
 
 def correct_time_mapping(time_to_correct, linear_fit, times, lags):
     """Adjust the time using a linear fit + a mapping from time to lag."""
     corrected = np.interp(time_to_correct + linear_fit * time_to_correct,
                           np.array(times) + lags, np.array(times))
-    return corrected
+    return round_to_sample(corrected)
+
+
+def round_to_sample(time_in_seconds, sample_rate=16000):
+    """
+
+    Args:
+        time_in_seconds:
+        sample_rate:
+
+    Returns:
+        time_in_seconds rounded such that time_in_seconds * sample_rate is an
+        integer
+
+
+    >>> 1 / 16000 - 0.000_062_5
+    0.0
+    >>> round_to_sample(1)
+    1.0
+    >>> round_to_sample(1.000_031_25)
+    1.0
+    >>> round_to_sample(1.000_031_26)
+    1.0000625
+    >>> round_to_sample(1.000_062_5)
+    1.0000625
+
+    """
+    return np.round(time_in_seconds * sample_rate) / sample_rate
 
 
 def align_kinect(kinect, transcription, align_data):

--- a/transcript_utils.py
+++ b/transcript_utils.py
@@ -37,7 +37,7 @@ def time_float_to_text(time_float):
     time_float %= 3600
     minutes = int(time_float/60)
     seconds = time_float % 60
-    return f'{hours}:{minutes:02d}:{seconds:05.2f}'
+    return f'{hours}:{minutes:02d}:{seconds:05.7f}'
 
 
 def load_transcript(session, root, convert=False):


### PR DESCRIPTION
This PR contains minimal modifications to remove unnecessary quantizations in the generated JSONs.
The old time stamps have 2 decimals. Two decimals have a resolution of 160 samples. So the quantization error can be in the worst case 159 samples also when the synchronization is perfect.

Workaround:
First round the float values (time in seconds) such that they represent a sample value (i.e. the number times the sampling rate is an integer).
Second, the written numbers use 7 decimals. This is necessary to keep the resolution.

My personal suggestion would be to use integers (samples) instead of floats (seconds) to save the time stamps. This makes it easier and more precise to work with them. Especially in the case when a synchronization is used. It prevents all rounding errors. For example, when in the JSON the number is saved with 7 decimals it is not guaranteed that the reader code considers 7 decimals.